### PR TITLE
Fix latest tag handling

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -24,8 +24,9 @@ export const run = async (inputs: Inputs): Promise<void> => {
     if (nonLatestTags.length === 0) {
       throw new Error(`when latest tag is given, also non-latest tag must be given`)
     }
-    const sourceManifest = nonLatestTags[0]
-    await dockerManifestCreatePush(latestTag, [sourceManifest])
+    const nonLatestTag = nonLatestTags[0]
+    const sourceManifests = getSourceManifests(nonLatestTag, inputs.suffixes)
+    await dockerManifestCreatePush(latestTag, sourceManifests)
     core.info(`Pushed a manifest ${latestTag}`)
   }
 }

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -36,6 +36,8 @@ describe('run', () => {
       ],
       suffixes: ['-amd64'],
     })
+
+    // non-latest tag
     expect(exec.exec).toHaveBeenCalledWith('docker', [
       'manifest',
       'create',
@@ -53,11 +55,12 @@ describe('run', () => {
       'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
     ])
 
+    // latest tag
     expect(exec.exec).toHaveBeenCalledWith('docker', [
       'manifest',
       'create',
       'ghcr.io/int128/docker-manifest-create-action:latest',
-      'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0-amd64',
     ])
     expect(exec.exec).toHaveBeenCalledWith('docker', [
       'manifest',


### PR DESCRIPTION
Fix the error in https://github.com/int128/docker-build-workflow/actions/runs/3811870362/jobs/6484778045:

```
/usr/bin/docker manifest create ghcr.io/int128/docker-build-workflow:latest ghcr.io/int128/docker-build-workflow:v1.0.1
ghcr.io/int128/docker-build-workflow:v1.0.1 is a manifest list
Error: Error: The process '/usr/bin/docker' failed with exit code 1
```