### PR TITLE
Support docker buildx

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
   suffixes:
     description: suffixes of source images (multi-line string)
     required: true
+  use-buildx:
+    description: use docker buildx (auto | true | false)
+    required: false
+    default: auto
 
 runs:
   using: 'node16'

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ const main = async (): Promise<void> => {
   await run({
     tags: core.getMultilineInput('tags', { required: true }),
     suffixes: core.getMultilineInput('suffixes', { required: true }),
+    useBuildx: core.getInput('use-buildx', { required: true }),
   })
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,6 +4,7 @@ import * as exec from '@actions/exec'
 type Inputs = {
   tags: string[]
   suffixes: string[]
+  useBuildx: string
 }
 
 export const run = async (inputs: Inputs): Promise<void> => {
@@ -11,16 +12,14 @@ export const run = async (inputs: Inputs): Promise<void> => {
     throw new Error(`one or more suffixes must be set`)
   }
 
-  core.startGroup('Checking if docker buildx is available')
-  await exec.exec('docker', ['version'])
-  const buildx = (await exec.exec('docker', ['buildx', 'version'], { ignoreReturnCode: true })) === 0
-  core.endGroup()
+  const useBuildx = await determineUseBuildx(inputs.useBuildx)
+  core.info(`Using ${useBuildx ? 'buildx' : 'docker'} command`)
 
   const nonLatestTags = inputs.tags.filter((tag) => !tag.endsWith(':latest'))
   const latestTag = inputs.tags.find((tag) => tag.endsWith(':latest'))
   for (const tag of nonLatestTags) {
     const sourceManifests = getSourceManifests(tag, inputs.suffixes)
-    await pushManifest(tag, sourceManifests, buildx)
+    await pushManifest(tag, sourceManifests, useBuildx)
     core.info(`Pushed a manifest ${tag}`)
   }
 
@@ -30,9 +29,26 @@ export const run = async (inputs: Inputs): Promise<void> => {
     }
     const nonLatestTag = nonLatestTags[0]
     const sourceManifests = getSourceManifests(nonLatestTag, inputs.suffixes)
-    await pushManifest(latestTag, sourceManifests, buildx)
+    await pushManifest(latestTag, sourceManifests, useBuildx)
     core.info(`Pushed a manifest ${latestTag}`)
   }
+}
+
+const determineUseBuildx = async (flag: string): Promise<boolean> => {
+  core.startGroup('Checking if docker buildx is available')
+  await exec.exec('docker', ['version'])
+  const buildxIsAvailable = (await exec.exec('docker', ['buildx', 'version'], { ignoreReturnCode: true })) === 0
+  core.endGroup()
+
+  switch (flag) {
+    case 'auto':
+      return buildxIsAvailable
+    case 'true':
+      return true
+    case 'false':
+      return false
+  }
+  throw new Error(`buildx must be either auto, true or false`)
 }
 
 export const getSourceManifests = (tag: string, suffixes: string[]) => suffixes.map((suffix) => `${tag}${suffix}`)

--- a/src/run.ts
+++ b/src/run.ts
@@ -48,7 +48,7 @@ const determineUseBuildx = async (flag: string): Promise<boolean> => {
     case 'false':
       return false
   }
-  throw new Error(`buildx must be either auto, true or false`)
+  throw new Error(`use-buildx must be either auto, true or false`)
 }
 
 export const getSourceManifests = (tag: string, suffixes: string[]) => suffixes.map((suffix) => `${tag}${suffix}`)

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -8,6 +8,7 @@ describe('run', () => {
     await run({
       tags: ['ghcr.io/int128/docker-manifest-create-action:main'],
       suffixes: ['-amd64', '-arm64'],
+      useBuildx: 'auto',
     })
     expect(exec.exec).toHaveBeenCalledWith('docker', [
       'manifest',
@@ -35,6 +36,7 @@ describe('run', () => {
         'ghcr.io/int128/docker-manifest-create-action:latest',
       ],
       suffixes: ['-amd64'],
+      useBuildx: 'auto',
     })
 
     // non-latest tag


### PR DESCRIPTION
## Problem to solve
We got this error message when pushing into ECR repository:

```
/usr/bin/docker manifest push ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY:TAG
failed to put manifest ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY:TAG: manifest blob unknown: Images with digests '[sha256:88016ce305fcf37355a5b0668ee51d8d919aaadefc0061933d86155ef3e2d528, sha256:a20a5fd0697fd676657eb839c231b117206497da7c2170e22d182a7db35a439d]' required for pushing image into repository with name 'REPOSITORY' in the registry with id 'ACCOUNT' do not exist
```

According to https://github.com/docker/cli/issues/3969#issuecomment-1386300525, docker buildx would help this problem. I could push the image by docker buildx commands:

```
docker buildx imagetools create -t ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY:TAG
[+] Building 0.4s (1/1) FINISHED                                                                                                                      
 => [internal] pushing ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY:TAG 0.4s
```

@semnil Thank you for pointing that issue of docker/cli.

## How to solve
Support `docker buildx imagetools create` command.
