### PR TITLE
feat: allow multi container registry

### DIFF
--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -72,6 +72,79 @@ describe('using buildx', () => {
       'ghcr.io/int128/docker-manifest-create-action:latest',
     ])
   })
+
+  test('multi container registry with latest', async () => {
+    await run({
+      tags: [
+        'int128/docker-manifest-create-action:v1.0.0',
+        'int128/docker-manifest-create-action:latest',
+        'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
+        'ghcr.io/int128/docker-manifest-create-action:latest',
+      ],
+      suffixes: ['-amd64'],
+      builder: 'auto',
+    })
+
+    // non-latest tag
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'create',
+      '-t',
+      'int128/docker-manifest-create-action:v1.0.0',
+      'int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'inspect',
+      'int128/docker-manifest-create-action:v1.0.0',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'create',
+      '-t',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'inspect',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
+    ])
+
+    // latest tag
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'create',
+      '-t',
+      'int128/docker-manifest-create-action:latest',
+      'int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'inspect',
+      'int128/docker-manifest-create-action:latest',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'create',
+      '-t',
+      'ghcr.io/int128/docker-manifest-create-action:latest',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'buildx',
+      'imagetools',
+      'inspect',
+      'ghcr.io/int128/docker-manifest-create-action:latest',
+    ])
+  })
 })
 
 describe('using docker', () => {
@@ -152,6 +225,87 @@ describe('using docker', () => {
       'manifest',
       'inspect',
       'ghcr.io/int128/docker-manifest-create-action:latest',
+    ])
+  })
+
+  test('multi container registry with latest', async () => {
+    await run({
+      tags: [
+        'int128/docker-manifest-create-action:v1.0.0',
+        'int128/docker-manifest-create-action:latest',
+        'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
+        'ghcr.io/int128/docker-manifest-create-action:latest',
+      ],
+      suffixes: ['-amd64'],
+      builder: 'auto',
+    })
+
+    // non-latest tag
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'create',
+      'int128/docker-manifest-create-action:v1.0.0',
+      'int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'push',
+      'int128/docker-manifest-create-action:v1.0.0',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'inspect',
+      'int128/docker-manifest-create-action:v1.0.0',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'create',
+      'ghcr.io/int128/docker-manifest-create-action:latest',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'push',
+      'ghcr.io/int128/docker-manifest-create-action:latest',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'inspect',
+      'ghcr.io/int128/docker-manifest-create-action:latest',
+    ])
+
+    // latest tag
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'create',
+      'int128/docker-manifest-create-action:latest',
+      'int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'push',
+      'int128/docker-manifest-create-action:latest',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'inspect',
+      'int128/docker-manifest-create-action:latest',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'create',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0-amd64',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'push',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
+    ])
+    expect(exec.exec).toHaveBeenCalledWith('docker', [
+      'manifest',
+      'inspect',
+      'ghcr.io/int128/docker-manifest-create-action:v1.0.0',
     ])
   })
 })


### PR DESCRIPTION
Example:

```yaml
jobs:
  build:
    strategy:
      fail-fast: false
      matrix:
        platform:
          - linux/amd64
          - linux/arm64
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - uses: docker/login-action@v2
        with:
          registry: ghcr.io
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}
      - uses: docker/metadata-action@v4
        id: metadata
        with:
          images: |
            ${{ secrets.DOCKER_HUB_USERNAME }}/my-repo-name
            ghcr.io/${{ github.repository }}
          # avoid overwriting the latest tag because metadata-action does not add a suffix to it
          flavor: latest=false,suffix=-${{ matrix.platform }}
      - uses: docker/setup-buildx-action@v2
      - uses: docker/build-push-action@v3
        with:
          push: true
          tags: ${{ steps.metadata.outputs.tags }}
          labels: ${{ steps.metadata.outputs.labels }}
          platforms: ${{ matrix.platform }}

  build-multi-architecture:
    needs:
      - build
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - uses: docker/login-action@v2
        with:
          registry: ghcr.io
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}
      - uses: docker/metadata-action@v4
        id: metadata
        with:
          images: |
            ${{ secrets.DOCKER_HUB_USERNAME }}/my-repo-name
            ghcr.io/${{ github.repository }}
      - uses: int128/docker-manifest-create-action@v1
        with:
          tags: ${{ steps.metadata.outputs.tags }}
          suffixes: |
            -linux-amd64
            -linux-arm64
```